### PR TITLE
Modified scraping methodology

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -104,7 +104,7 @@ The following endpoints provide functionality related to users of the applicatio
 
 #### Scraping Endpoints
 
-`GET /scrape-recipe`: Accepts query parameters of Edamam recipe link and Edamam recipe source. Calls `determineSite()` which determines the site of origin and creates a scraper for the recipe directions in that site. `determineSite()` calls `getRecipeDirectionsFromSource()`, which gets the text content of the recipe directions on the respective site. Recipe data is ultimately returned as a JSON object to `/scrape-recipe`.
+`GET /scrape-recipe`: Accepts query parameters of Edamam recipe link and Edamam recipe source. Calls  `getRecipeDirectionsFromSource()`, which gets the text content of the recipe directions on the respective site. Recipe data is ultimately returned as a JSON object to `/scrape-recipe`.
 
 ### Models
 

--- a/client/public/static/js/recipes/recipe_details.js
+++ b/client/public/static/js/recipes/recipe_details.js
@@ -6,7 +6,9 @@ function RecipeDetailsView() {
 
       try {
         const recipeDetails = await this.getRecipeDetails(recipeUri);
-        const recipeInstructions = await this.getRecipeInstructions(source, sourceUrl);
+        const recipe = recipeDetails.hits[0].recipe;
+        const recipeName = recipe.label;
+        const recipeInstructions = await this.getRecipeInstructions(source, sourceUrl, recipe.label);
 
         if (isValidResult(recipeDetails)) {
           this.buildView(recipeDetails, recipeInstructions);
@@ -66,9 +68,9 @@ function RecipeDetailsView() {
     }
   }
 
-  this.getRecipeInstructions = async (source, sourceUrl) => {
+  this.getRecipeInstructions = async (source, sourceUrl, recipeName) => {
     const sourceTrimmed = source.toLowerCase().trim();
-    const apiUrl = `${RECIPE_SCRAPE_URL}/?recipeLink=${sourceUrl}&source=${sourceTrimmed}`;
+    const apiUrl = `${RECIPE_SCRAPE_URL}/?recipeLink=${sourceUrl}&source=${sourceTrimmed}&recipeName=${recipeName}`;
 
     console.log("Querying Server for:", apiUrl);
 
@@ -211,14 +213,17 @@ function RecipeDetailsView() {
         preparationList.appendChild(listItem);
       });
     } else {
-      const source = recipe.source;
-      const url = recipe.url;
-
       console.log(`No scraped instructions for: [${recipe.label}]`);
       const noInstructionsText = document.createElement('p');
-      noInstructionsText.innerHTML = `No instructions available. View more at <a href="${url}" target="_blank">${source}</a>`;
+      noInstructionsText.innerHTML = `No instructions were able to be migrated.`;
       preparationContainer.appendChild(noInstructionsText);
     }
+    const source = recipe.source;
+    const url = recipe.url;
+
+    const urlLinkToInstructionsText = document.createElement('p');
+    urlLinkToInstructionsText.innerHTML = `View full instructions and more at <a href="${url}" target="_blank">${source}</a>`;
+    preparationContainer.appendChild(urlLinkToInstructionsText);
 
     // Update nutritional facts
     const nutritionalFactsList = document.querySelectorAll('.recipe-info')[2].querySelector('ul');

--- a/server/routes/endpoints.js
+++ b/server/routes/endpoints.js
@@ -146,9 +146,10 @@ endpoints.get('/edamam', async (req, res) => {
 endpoints.get('/scrape-recipe', async (req, res) => {
   const recipeLink = req.query.recipeLink;
   const source = req.query.source;
+  const recipeName = req.query.recipeName;
 
   try {
-    const data = await determineSite(recipeLink, source);
+    const data = await getRecipeDirectionsFromSource(recipeLink, recipeName);
     console.log("SCRAPED DATA: " + data);
     res.json(data);
   } catch (error) {
@@ -157,65 +158,74 @@ endpoints.get('/scrape-recipe', async (req, res) => {
   }
 });
 
-async function determineSite(link, source) {
-  console.log("Link in determineSite(): " + link);
-  console.log("Source in determineSite() |" + source + "|");
-
-  let data = [];
-  let scraper;
-  let findScraper;
-
-  try {
-    switch (source.toLowerCase()) { // Use toLowerCase() to handle case variations
-      case 'bbc good food':
-        scraper = '.js-piano-recipe-method .grouped-list__list li';
-        findScraper = 'p';
-        break;
-      case 'simply recipes':
-        scraper = '#mntl-sc-block_3-0';
-        findScraper = 'p.mntl-sc-block-html';
-        break;
-      case 'martha stewart':
-        scraper = 'div#recipe__steps-content_1-0 p';
-        findScraper = '';
-        break;
-      case 'food network':
-        scraper = '.o-Method__m-Body ol';
-        findScraper = 'li';
-        break;
-      case 'delish':
-        scraper = 'ul.directions li ol';
-        findScraper = 'li';
-        break;
-      case 'eatingwell':
-        scraper = 'div#recipe__steps-content_1-0 ol li';
-        findScraper = 'p';
-        break;
-      default:
-        throw new Error("Unsupported source provided.");
-    }
-
-    data = await getRecipeDirectionsFromSource(link, scraper, findScraper);
-    console.log("directions: " + data);
-    return data;
-  } catch (error) {
-    console.error("Error in determineSite:", error);
-    throw error;
-  }
-}
-
-async function getRecipeDirectionsFromSource(link, scraper, findScraper) {
+async function getRecipeDirectionsFromSource(link, recipeName) {
   console.log(`Made it to get data. Link = ${link}`);
   try {
     const response = await axios.get(link);
     const html = response.data;
     const $ = cheerio.load(html);
+    const directionsScrape = '*:not(script,style,noscript,figcaption)';
     const recipeDirections = [];
+    var startScrapingDirections = false;
+    var firstElementRead = false;
+    var stopScraping = false;
+    var classNameOfElement = '';
+    var firstInstructionElement ='';
 
-    $(scraper).each((index, element) => {
-      const directionElement = findScraper ? $(element).find(findScraper) : $(element);
-      const directionText = directionElement.text().trim().split('\n\n');
-      recipeDirections.push(directionText);
+    $(directionsScrape).each((index,element) => {
+      if(!stopScraping){
+        var htmlObjectContents = ($(element).contents().filter(function() {
+          return this.type === 'text';
+        }).text().trim());
+        if(htmlObjectContents.length === 0 || htmlObjectContents.length === undefined){
+        }else{
+          if(startScrapingDirections){
+            classNameOfElement = $(element).get(0).tagName;
+            var elementResult = classNameOfElement.localeCompare(firstInstructionElement);
+            htmlObjectContentsLower = htmlObjectContents.toLowerCase()
+            var resultReview = htmlObjectContentsLower.indexOf("reviews");
+            var commentsReview = htmlObjectContentsLower.indexOf("comments");
+            if((firstElementRead && (elementResult != 0) && (htmlObjectContents.length > 30)) || (resultReview >= 0) || (commentsReview >= 0)){
+              stopScraping = true;
+            }else{
+            /*at this point string length of 30 is an arbitrary number that is used to disregard image captions or other random strings between steps
+            unfortunately this can also cause issues with some other recipes that have really long subtitles for each step*/
+              if(htmlObjectContents.length > 30){
+                if(!firstElementRead){
+                  firstElementRead = true;
+                  firstInstructionElement = classNameOfElement;
+                }
+                recipeDirections.push(htmlObjectContents);
+              }
+            }
+          }
+
+          if(!startScrapingDirections){
+            htmlObjectContentsLower = htmlObjectContents.toLowerCase()
+            var result = htmlObjectContentsLower.localeCompare("directions");
+            if(result === 0){
+              console.log('found directions and will start scraping');
+              startScrapingDirections = true;
+            }
+            result = htmlObjectContentsLower.localeCompare("instructions");
+            if(result === 0){
+              console.log('found instructions and will start scraping');
+              startScrapingDirections = true;
+            }
+            result = htmlObjectContentsLower.localeCompare("method");
+            if(result === 0){
+              console.log('found method and will start scraping');
+              startScrapingDirections = true;
+            }
+            /*result = htmlObjectContents.localeCompare(recipeName);
+            if(result === 0){
+              console.log('found directions and will start scraping');
+              startScrapingDirections = true;
+              console.log(htmlObjectContents);
+            }*/
+          }
+        }
+      }
     });
 
     console.log(`Recipe directions: ${recipeDirections}`);

--- a/server/routes/endpoints.js
+++ b/server/routes/endpoints.js
@@ -217,6 +217,11 @@ async function getRecipeDirectionsFromSource(link, recipeName) {
               console.log('found method and will start scraping');
               startScrapingDirections = true;
             }
+            result = htmlObjectContentsLower.localeCompare("preparation");
+            if(result === 0){
+              console.log('found method and will start scraping');
+              startScrapingDirections = true;
+            }
             /*result = htmlObjectContents.localeCompare(recipeName);
             if(result === 0){
               console.log('found directions and will start scraping');


### PR DESCRIPTION
Scraping methodology has been changed to allow for a wider array of websites to be scraped. Rather than manually making a specific scraper for the 500+ websites that the EDAMAM API utilizes, a more generic scraping approach has been implemented. We now look for directions/instructions/methods to know when to start scraping. When one of those are found we look for the next element to determine the expected element type of the instructions. While the next element types match the original child type we keep scraping. We stop scraping if the element type changes and has a string length greater than 30 (arbitrary number as of right now) or if we are at the reviews or comments section. Also, during scraping if the element matches the original element, but is less than 30 chars in length we don't add to the directions as it is more than likely a picture caption or image tag.